### PR TITLE
Bugfix/#211/event-logging-only-prints-out-100-attendees-max

### DIFF
--- a/src/commands/chat/moderation.ts
+++ b/src/commands/chat/moderation.ts
@@ -1,31 +1,34 @@
 import {
-	ActionRowBuilder,
-	ButtonBuilder,
-	ButtonStyle,
-	ChatInputCommandInteraction,
-	inlineCode,
-	InteractionContextType,
-	InteractionReplyOptions,
-	MessageFlags,
-	PermissionFlagsBits,
-	SlashCommandBuilder,
-	SlashCommandStringOption,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ChatInputCommandInteraction,
+  inlineCode,
+  InteractionContextType,
+  InteractionReplyOptions,
+  MessageFlags,
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+  SlashCommandStringOption,
 } from "discord.js";
 import { FilterQuery } from "mongoose";
 import { ChatInputCommand } from "../../Classes/index.js";
 import {
-	modViewWarningHistory,
-	updateWarnById,
+  modViewWarningHistory,
+  updateWarnById,
 } from "../../features/moderation/buttons.js";
 import {
-	viewWarningEmbed,
-	viewWarningEmbeds,
+  viewWarningEmbed,
+  viewWarningEmbeds,
 } from "../../features/moderation/embeds.js";
-import { dateDiffInDays, WARN_MAX_CHAR } from "../../features/moderation/index.js";
+import {
+  dateDiffInDays,
+  WARN_MAX_CHAR,
+} from "../../features/moderation/index.js";
 import { warnModal } from "../../features/moderation/modals.js";
 import {
-	WarnButtonsPrefixes,
-	WarnModalPrefixes,
+  WarnButtonsPrefixes,
+  WarnModalPrefixes,
 } from "../../features/moderation/types.js";
 import { warnSearch } from "../../features/moderation/warnSearch.js";
 import { Warn, WarningRecord } from "../../models/Warn.js";
@@ -71,7 +74,7 @@ export const warn = new ChatInputCommand({
           option
             .setName("reason")
             .setDescription("Add reason for the warning")
-			.setMaxLength(WARN_MAX_CHAR)
+            .setMaxLength(WARN_MAX_CHAR)
             .setRequired(false),
         )
         .addIntegerOption((option) =>

--- a/src/events/guild_scheduled_event/guildScheduledEventUpdate.ts
+++ b/src/events/guild_scheduled_event/guildScheduledEventUpdate.ts
@@ -39,6 +39,8 @@ export const guildScheduledEventUpdate = new Event({
           return usr.id;
         }),
       })) as IScheduledEvent;
+
+      await logScheduledEvent(res);
     } else {
       res = (
         await ScheduledEvent.find({ eventId: newEvent.id })

--- a/src/events/guild_scheduled_event/guildScheduledEventUpdate.ts
+++ b/src/events/guild_scheduled_event/guildScheduledEventUpdate.ts
@@ -78,16 +78,18 @@ export const guildScheduledEventUpdate = new Event({
       if (oldEvent.isActive() && newEvent.isCompleted()) {
         console.log("ending one time event");
         res.endedAt = new Date(Date.now());
+
+        await logScheduledEvent(res);
       }
     } else {
       if (oldEvent.isActive() && newEvent.isScheduled()) {
         console.log("ending recurring event");
         res.endedAt = new Date(Date.now());
+
+        await logScheduledEvent(res);
       }
     }
 
     await res.save();
-
-    await logScheduledEvent(res);
   },
 });

--- a/src/features/logging/scheduledEvent.ts
+++ b/src/features/logging/scheduledEvent.ts
@@ -80,11 +80,13 @@ export async function logScheduledEvent(event: IScheduledEvent) {
         components: [await container],
         files: [file],
         flags: MessageFlags.IsComponentsV2,
+        allowedMentions: { parse: [] },
       });
     } else {
       post = await logChannel.send({
         components: [await container],
         flags: MessageFlags.IsComponentsV2,
+        allowedMentions: { parse: [] },
       });
     }
     event.logMessageId = post.id;

--- a/src/features/logging/scheduledEvent.ts
+++ b/src/features/logging/scheduledEvent.ts
@@ -1,20 +1,20 @@
 import {
-  AttachmentBuilder,
-  ButtonBuilder,
-  ButtonStyle,
-  ChannelType,
-  ContainerBuilder,
-  DiscordAPIError,
-  Guild,
-  heading,
-  HeadingLevel,
-  MessageFlags,
-  RESTJSONErrorCodes,
-  SectionBuilder,
-  SeparatorBuilder,
-  SeparatorSpacingSize,
-  TextDisplayBuilder,
-  ThumbnailBuilder,
+	AttachmentBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	ChannelType,
+	ContainerBuilder,
+	DiscordAPIError,
+	Guild,
+	heading,
+	HeadingLevel,
+	MessageFlags,
+	RESTJSONErrorCodes,
+	SectionBuilder,
+	SeparatorBuilder,
+	SeparatorSpacingSize,
+	TextDisplayBuilder,
+	ThumbnailBuilder,
 } from "discord.js";
 import { client } from "../../index.js";
 import { IScheduledEvent } from "../../models/ScheduledEvent.js";
@@ -70,6 +70,7 @@ export async function logScheduledEvent(event: IScheduledEvent) {
     await existingPost.edit({
       components: [await container],
       flags: MessageFlags.IsComponentsV2,
+      allowedMentions: { parse: [] },
     });
   } else {
     const container = logContainer(event);
@@ -107,7 +108,7 @@ async function logContainer(event: IScheduledEvent) {
     attendees.length > 0
       ? attendees
           .map((usr) => {
-            return `\n- ${usr.toString()}`;
+            return `\n- ${usr}`;
           })
           .toString()
       : "";

--- a/src/features/moderation/index.ts
+++ b/src/features/moderation/index.ts
@@ -1,7 +1,7 @@
 // milliseconds in a day
 const _MS_PER_DAY = 1000 * 60 * 60 * 24;
 
-export const WARN_MAX_CHAR = 2000
+export const WARN_MAX_CHAR = 2000;
 
 /**
  * Find the difference in days between two date Objects

--- a/src/features/moderation/modals.ts
+++ b/src/features/moderation/modals.ts
@@ -1,8 +1,8 @@
 import {
-	ActionRowBuilder,
-	ModalBuilder,
-	TextInputBuilder,
-	TextInputStyle,
+  ActionRowBuilder,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
 } from "discord.js";
 import { WARN_MAX_CHAR } from "./index.js";
 import { defaultNumberOfDaysBeforeExpiration } from "./types.js";
@@ -24,7 +24,7 @@ export function warnModal(
   const reasonInput = new TextInputBuilder()
     .setCustomId("reason")
     .setLabel("Reason for issuing this warning")
-	.setMaxLength(WARN_MAX_CHAR)
+    .setMaxLength(WARN_MAX_CHAR)
     .setStyle(TextInputStyle.Paragraph)
     .setRequired(true);
 

--- a/src/features/test/test.ts
+++ b/src/features/test/test.ts
@@ -1,0 +1,3 @@
+import { ChatInputCommandInteraction } from "discord.js";
+
+export default async function (interaction: ChatInputCommandInteraction) {}

--- a/src/util/scheduledEventWrapper.ts
+++ b/src/util/scheduledEventWrapper.ts
@@ -123,10 +123,10 @@ export class ScheduledEventWrapper {
   };
 
   attendees = async () => {
-    const users = await (
-      await this.guild()
-    ).members.fetch({ user: this.event.attendees, withPresences: true });
-    return users.values().toArray();
+    const users = this.event.attendees.map((usr) => {
+      return `<@${usr}>`;
+    });
+    return users;
   };
 
   userCount = () => {


### PR DESCRIPTION
# Several Event Logging Bug Fixes
- Attendee listings no longer ping
- ScheduledEventWrapper no longer queries discord for member data with a list of IDs
  - runs faster
  - no longer limited to printing a max of 100 attendees
- Now only prints log entries when creating or ending events

## Full description
This fixes several ongoing bugs with the event logging including #211, #212, and #210. This may open up a character overflow issue with too many attendees so I need to make the file paste alternative next.
